### PR TITLE
feat: /docs/releases API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 yarn-error.log
 .textlintcache
+releases.json

--- a/api.js
+++ b/api.js
@@ -3,6 +3,7 @@ const path = require('path')
 const express = require('express')
 
 const utils = require('./utils')
+const { getReleases } = require('./releases')
 
 const fs = bluebird.promisifyAll(require('fs'))
 const app = express()
@@ -50,5 +51,15 @@ app.listen(port)
         })
       )
     })
+  })
+
+  app.get('/docs/releases', async (req, res) => {
+    try {
+      const releases = await getReleases()
+      res.json(releases)
+    } catch (error) {
+      res.statusCode = 500
+      res.end(JSON.stringify(error.response ? error.response.data : { error: error + '' }))
+    }
   })
 })()

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint:md:fix": "./scripts/lint-md-fix"
   },
   "dependencies": {
+    "axios": "^0.18.0",
     "bluebird": "^3.5.3",
     "express": "^4.16.4",
     "yamljs": "^0.3.0"

--- a/releases.js
+++ b/releases.js
@@ -1,0 +1,46 @@
+const axios = require('axios')
+const fs = require('fs')
+
+const githubApiUrl = 'https://api.github.com/repos/sarahdayan/dinero.js/releases'
+
+// TODO: Create one from https://github.com/settings/tokens/new without any scope but keep it SECRET (not version control)
+const githubToken = process.env.GITHUB_TOKEN
+if (!githubToken) {
+  console.warn('WARNING: No GITHUB_TOKEN set!')
+}
+
+let data = fs.existsSync('releases.json') ? JSON.parse(fs.readFileSync('releases.json')) : { _time: -1 , releases: [{}] }
+
+async function getReleases() {
+  const now = Date.now()
+
+  // Cache for 30 minutes
+  if (now - data.time < 1000 * 60 * 30) {
+    return data
+  }
+
+  const releases = await axios.get(githubApiUrl, {
+    headers: {
+      Authorization: githubToken ? `token ${githubToken}` : undefined
+    }
+  })
+    .then(r => r.data)
+    .catch(error => {
+      console.error(`Error while fetching releases. Using old cache! (${error})`)
+      return data.releases
+    })
+
+  data = {
+    time: now,
+    releases
+  }
+
+  // Write in background
+  fs.writeFile('releases.json', JSON.stringify(data), () => { })
+
+  return data
+}
+
+module.exports = {
+  getReleases
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -343,6 +343,14 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
+  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
+  dependencies:
+    follow-redirects "^1.3.0"
+    is-buffer "^1.1.5"
+
 bail@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.3.tgz#63cfb9ddbac829b02a3128cd53224be78e6c21a3"
@@ -764,7 +772,7 @@ debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -1166,6 +1174,13 @@ fn-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
   integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
+
+follow-redirects@^1.3.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
+  integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
+  dependencies:
+    debug "^3.2.6"
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR adds `/docs/releases` API for fetching releases from GitHub API. Responses are cached both in memory and on disk for 30 minutes. Setting `GITHUB_TOKEN` env to prevent rate limits is highly recommended.

Friendly suggestion (not related to this PR): When API is heavily dependent on async operations using an async native framework like fastify, hapi or koa makes things easier.

Related PR: dinerojs/dinerojs.com#1